### PR TITLE
Suppresses C++ name mangling

### DIFF
--- a/cmp.h
+++ b/cmp.h
@@ -1,6 +1,10 @@
 #ifndef CMP_H__
 #define CMP_H__
 
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 struct cmp_ctx_s;
 
 typedef bool   (*cmp_reader)(struct cmp_ctx_s *ctx, void *data, size_t limit);
@@ -345,6 +349,10 @@ bool cmp_read_ext16_marker(cmp_ctx_t *ctx, int8_t *type, uint16_t *size);
 bool cmp_read_ext16(cmp_ctx_t *ctx, int8_t *type, uint16_t *size, void *data);
 bool cmp_read_ext32_marker(cmp_ctx_t *ctx, int8_t *type, uint32_t *size);
 bool cmp_read_ext32(cmp_ctx_t *ctx, int8_t *type, uint32_t *size, void *data);
+
+#if defined (__cplusplus)
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
When linking _cmp_ against C++, the exported symbols from `cmp.h` are different due to C++ name mangling. The `extern "C"` block suppresses that.
