### PR TITLE
Fix warnings

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -321,7 +321,7 @@ bool cmp_write_sint(cmp_ctx_t *ctx, int64_t d) {
   if (d >= -32768)
     return cmp_write_s16(ctx, d);
   if (d >= (-2147483647 - 1))
-    return cmp_write_s32(ctx, d);
+    return cmp_write_s32(ctx, (int32_t) d);
 
   return cmp_write_s64(ctx, d);
 }
@@ -372,7 +372,7 @@ bool cmp_write_uint(cmp_ctx_t *ctx, uint64_t u) {
   if (u <= 0xFFFF)
     return cmp_write_u16(ctx, u);
   if (u <= 0xFFFFFFFF)
-    return cmp_write_u32(ctx, u);
+    return cmp_write_u32(ctx, (uint32_t) u);
 
   return cmp_write_u64(ctx, u);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -471,12 +471,12 @@ static void error_printf(const char *msg, ...);
     }                                                                         \
     if (var1 != val1) {                                                       \
       error_printf("%s:%d ", __func__, __LINE__);                             \
-      error_printf("First array value != %d (%lu)\n", val1, var1);            \
+      error_printf("First array value != %d (%llu)\n", val1, var1);           \
       return false;                                                           \
     }                                                                         \
     if (var2 != val2) {                                                       \
       error_printf("%s:%d ", __func__, __LINE__);                             \
-      error_printf("Second array value != %d (%lu)\n", val2, var2);           \
+      error_printf("Second array value != %d (%llu)\n", val2, var2);          \
       return false;                                                           \
     }                                                                         \
   } while (0);

--- a/test/test.c
+++ b/test/test.c
@@ -471,12 +471,12 @@ static void error_printf(const char *msg, ...);
     }                                                                         \
     if (var1 != val1) {                                                       \
       error_printf("%s:%d ", __func__, __LINE__);                             \
-      error_printf("First array value != %d (%llu)\n", val1, var1);           \
+      error_printf("First array value != %d (%" PRIu64 ")\n", val1, var1);           \
       return false;                                                           \
     }                                                                         \
     if (var2 != val2) {                                                       \
       error_printf("%s:%d ", __func__, __LINE__);                             \
-      error_printf("Second array value != %d (%llu)\n", val2, var2);          \
+      error_printf("Second array value != %d (%" PRIu64 ")\n", val2, var2);          \
       return false;                                                           \
     }                                                                         \
   } while (0);


### PR DESCRIPTION
I fixed some warnings generated by Clang (included in Xcode 6.1.1). Seems to work fine with GCC 4.9.