### PR TITLE
Fixed cmp_read_ufix expecting negative, not positive fixints.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -1280,18 +1280,7 @@ bool cmp_read_sinteger(cmp_ctx_t *ctx, int64_t *d) {
 }
 
 bool cmp_read_ufix(cmp_ctx_t *ctx, uint8_t *c) {
-  cmp_object_t obj;
-
-  if (!cmp_read_object(ctx, &obj))
-    return false;
-
-  if (obj.type != CMP_TYPE_NEGATIVE_FIXNUM) {
-    ctx->error = INVALID_TYPE_ERROR;
-    return false;
-  }
-
-  *c = obj.as.u8;
-  return true;
+  return cmp_read_pfix(ctx, c);
 }
 
 bool cmp_read_u8(cmp_ctx_t *ctx, uint8_t *c) {


### PR DESCRIPTION
The function cmp_write_ufix() is a wrapper for cmp_write_pfix(). But cmp_read_ufix() is expecting a negative int. This changes read_ufix() to be a wrapper to read_pfix().

Simple test case:
```C
cmp_write_ufix(&ctx, 42);
/* seek back to start of ufix */
uint8_t data;
cmp_read_ufix(&ctx, &data);
/* error */
```