### PR TITLE
put dependencies in header as the header depends on them

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -22,11 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-
-#include "cmp.h"
+#include <cmp.h>
 
 static const uint32_t version = 14;
 static const uint32_t mp_version = 5;

--- a/cmp.h
+++ b/cmp.h
@@ -25,6 +25,10 @@ THE SOFTWARE.
 #ifndef CMP_H__
 #define CMP_H__
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 struct cmp_ctx_s;
 
 typedef bool   (*cmp_reader)(struct cmp_ctx_s *ctx, void *data, size_t limit);


### PR DESCRIPTION
if you try to include cmp.h on its own without the headers it depends on compilation will fail.