### PR TITLE
Import the c headers providing the types used in cmp.h 

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -22,10 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-
 #include "cmp.h"
 
 static const uint32_t version = 14;

--- a/cmp.h
+++ b/cmp.h
@@ -25,6 +25,10 @@ THE SOFTWARE.
 #ifndef CMP_H__
 #define CMP_H__
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 struct cmp_ctx_s;
 
 typedef bool   (*cmp_reader)(struct cmp_ctx_s *ctx, void *data, size_t limit);


### PR DESCRIPTION
Seems like these headers would live better in the cmp.h than cmp.c.

Is there an advantage to not including the c header libraries in the cmp.h?  Would someone potentially use a different set of headers to import the [u]int*_t types?

I didn't update the tests or examples, as I don't use them, but making this change would remove the need to import stdbool, stddef, and stdint from them as well.