### PR TITLE
Added skipping support

### DIFF
--- a/cmp.h
+++ b/cmp.h
@@ -299,6 +299,9 @@ bool cmp_read_ext(cmp_ctx_t *ctx, int8_t *type, uint32_t *size, void *data);
 /* Reads an object from the backend */
 bool cmp_read_object(cmp_ctx_t *ctx, cmp_object_t *obj);
 
+/* Skips an object from the backend */
+bool cmp_skip_object(cmp_ctx_t *ctx);
+
 /*
  * ============================================================================
  * === Specific API


### PR DESCRIPTION
This is another attempt to add skipping support (see also #5). This implementation is based on code from CWPack and does not use recursion.

Before this is merged, two things should be considered:
1. obj_skip_count is currently a uint32_t and could overflow (e.g. while reading malicious data). Extending the type to uint64_t would help with the problem (at least a bit), but I didn't really want to change it, since I use cmp on an embedded device. Maybe instead, we could check for overflow and exit with an error.
2. Skipping of strings/bin/ext currently reads one byte at a time, since there is no buffer available. This could be replaced with a skip/seek function pointer. Instead a buffer of configurable size could be added (see #3).
