### PR TITLE
Fix implicit float conversion warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,9 @@ cmptest2
 # Example executables
 examples/example1
 examples/example2
+example1
+example2
+
+# Test data
+cmp_data.dat
 

--- a/cmp.c
+++ b/cmp.c
@@ -945,7 +945,7 @@ bool cmp_write_double(cmp_ctx_t *ctx, double d) {
 
 bool cmp_write_decimal(cmp_ctx_t *ctx, double d) {
   float f = (float)d;
-  float df = (double)f;
+  double df = (double)f;
 
   if (df == d)
     return cmp_write_float(ctx, f);


### PR DESCRIPTION
Here as you requested :) Also added some binary ignores. Btw do you want to keep examples/cmp_data.dat and the build/run sh scripts anymore?