### PR TITLE
Develop

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -2657,7 +2657,7 @@ bool cmp_skip_object(cmp_ctx_t *ctx, cmp_object_t *obj) {
 }
 
 bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
-  uint64_t element_count = 1;
+  size_t element_count = 1;
   uint32_t depth = 0;
 
   while (element_count) {
@@ -2702,6 +2702,20 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
         }
 
         if (size) {
+          switch (cmp_type) {
+            case CMP_TYPE_FIXEXT1:
+            case CMP_TYPE_FIXEXT2:
+            case CMP_TYPE_FIXEXT4:
+            case CMP_TYPE_FIXEXT8:
+            case CMP_TYPE_FIXEXT16:
+            case CMP_TYPE_EXT8:
+            case CMP_TYPE_EXT16:
+            case CMP_TYPE_EXT32:
+              size++;
+            default:
+              break;
+          }
+
           skip_bytes(ctx, size);
         }
     }
@@ -2723,7 +2737,7 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
         if (!read_type_size(ctx, type_marker, cmp_type, &size)) {
           return false;
         }
-        element_count += ((uint64_t)size) * 2;
+        element_count += ((size_t)size) * 2;
         break;
       default:
         break;
@@ -2734,7 +2748,7 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
 }
 
 bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
-  uint64_t element_count = 1;
+  size_t element_count = 1;
 
   while (element_count) {
     uint8_t type_marker = 0;
@@ -2763,8 +2777,23 @@ bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
           return false;
         }
 
-        if (size)
+        if (size) {
+          switch (cmp_type) {
+            case CMP_TYPE_FIXEXT1:
+            case CMP_TYPE_FIXEXT2:
+            case CMP_TYPE_FIXEXT4:
+            case CMP_TYPE_FIXEXT8:
+            case CMP_TYPE_FIXEXT16:
+            case CMP_TYPE_EXT8:
+            case CMP_TYPE_EXT16:
+            case CMP_TYPE_EXT32:
+              size++;
+            default:
+              break;
+          }
+
           skip_bytes(ctx, size);
+        }
     }
 
     element_count--;
@@ -2784,7 +2813,7 @@ bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
         if (!read_type_size(ctx, type_marker, cmp_type, &size)) {
           return false;
         }
-        element_count += ((uint64_t)size) * 2;
+        element_count += ((size_t)size) * 2;
         break;
       default:
         break;

--- a/cmp.c
+++ b/cmp.c
@@ -2996,6 +2996,9 @@ bool cmp_object_as_char(cmp_object_t *obj, int8_t *c) {
         *c = obj->as.s8;
         return true;
       }
+      else {
+        return false;
+      }
     default:
         return false;
   }
@@ -3018,6 +3021,9 @@ bool cmp_object_as_short(cmp_object_t *obj, int16_t *s) {
       if (obj->as.u16 <= 32767) {
         *s = obj->as.u16;
         return true;
+      }
+      else {
+        return false;
       }
     default:
         return false;
@@ -3047,6 +3053,9 @@ bool cmp_object_as_int(cmp_object_t *obj, int32_t *i) {
       if (obj->as.u32 <= 2147483647) {
         *i = obj->as.u32;
         return true;
+      }
+      else {
+        return false;
       }
     default:
         return false;
@@ -3082,6 +3091,9 @@ bool cmp_object_as_long(cmp_object_t *obj, int64_t *d) {
       if (obj->as.u64 <= 9223372036854775807) {
         *d = obj->as.u64;
         return true;
+      }
+      else {
+        return false;
       }
     default:
         return false;

--- a/test/test.c
+++ b/test/test.c
@@ -3347,6 +3347,10 @@ static void test_ext(void **state) {
   assert_memory_equal(outbuf32, buf32, 16);
 
   M_BufferSeek(&buf, 0);
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_true(cmp_object_as_ext(&obj, &etype, &esize32));
+
+  M_BufferSeek(&buf, 0);
 
   assert_true(cmp_write_ext_marker(&cmp, 2, 1));
   assert_true(cmp_write_ext_marker(&cmp, 3, 2));
@@ -4193,30 +4197,32 @@ void test_skipping(void **state) {
   assert_true(cmp_write_nil(&cmp));
   assert_true(cmp_write_integer(&cmp, -8));
   assert_true(cmp_write_array(&cmp, 10));
-  assert_true(cmp_write_uinteger(&cmp, 8));
-  assert_true(cmp_write_integer(&cmp, -120));
-  assert_true(cmp_write_uinteger(&cmp, 200));
-  assert_true(cmp_write_integer(&cmp, -32000));
-  assert_true(cmp_write_uinteger(&cmp, 64000));
-  assert_true(cmp_write_integer(&cmp, -33000));
-  assert_true(cmp_write_uinteger(&cmp, 66000));
-  assert_true(cmp_write_integer(&cmp, -2150000000));
-  assert_true(cmp_write_uinteger(&cmp, 4300000000));
-  assert_true(cmp_write_map(&cmp, 3));
-  assert_true(cmp_write_str(&cmp, "a", 1));
-  assert_true(cmp_write_str(&cmp, "apple", 5));
-  assert_true(cmp_write_str(&cmp, "b", 1));
-  assert_true(cmp_write_array(&cmp, 2));
-  assert_true(cmp_write_str(&cmp, "banana", 6));
-  assert_true(cmp_write_str(&cmp, "blackberry", 10));
-  assert_true(cmp_write_str(&cmp, "c", 1));
-  assert_true(cmp_write_str(&cmp, "coconut", 7));
+    assert_true(cmp_write_uinteger(&cmp, 8));
+    assert_true(cmp_write_integer(&cmp, -120));
+    assert_true(cmp_write_uinteger(&cmp, 200));
+    assert_true(cmp_write_integer(&cmp, -32000));
+    assert_true(cmp_write_uinteger(&cmp, 64000));
+    assert_true(cmp_write_integer(&cmp, -33000));
+    assert_true(cmp_write_uinteger(&cmp, 66000));
+    assert_true(cmp_write_integer(&cmp, -2150000000));
+    assert_true(cmp_write_uinteger(&cmp, 4300000000));
+    assert_true(cmp_write_map(&cmp, 3));
+      assert_true(cmp_write_str(&cmp, "a", 1));
+        assert_true(cmp_write_str(&cmp, "apple", 5));
+      assert_true(cmp_write_str(&cmp, "b", 1));
+        assert_true(cmp_write_array(&cmp, 2));
+          assert_true(cmp_write_str(&cmp, "banana", 6));
+          assert_true(cmp_write_str(&cmp, "blackberry", 10));
+      assert_true(cmp_write_str(&cmp, "c", 1));
+        assert_true(cmp_write_str(&cmp, "coconut", 7));
   assert_true(cmp_write_map(&cmp, 66000));
 
   for (uint32_t i = 0; i < 66000; i++) {
-    cmp_write_integer(&cmp, 1);
-    cmp_write_integer(&cmp, 1);
+    assert_true(cmp_write_integer(&cmp, 1));
+    assert_true(cmp_write_integer(&cmp, 1));
   }
+
+  assert_true(cmp_write_nil(&cmp));
 
   M_BufferSeek(&buf, 0);
   assert_true(cmp_skip_object(&cmp, &obj));
@@ -4228,14 +4234,40 @@ void test_skipping(void **state) {
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_false(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
   cmp.skip = skip;
 
   M_BufferSeek(&buf, 0);
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_false(cmp_skip_object(&cmp, &obj));
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
   assert_false(cmp_skip_object_limit(&cmp, &obj, 1));
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_false(cmp_skip_object_limit(&cmp, &obj, 2));
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_limit(&cmp, &obj, 3));
 
   M_BufferSeek(&buf, 0);
   assert_true(cmp_read_object(&cmp, &obj));
@@ -4291,14 +4323,6 @@ void test_skipping(void **state) {
   M_BufferSeekForward(&buf, 7);
   assert_true(cmp_read_object(&cmp, &obj));
   assert_int_equal(obj.type, CMP_TYPE_MAP32);
-
-  M_BufferSeek(&buf, 0);
-  assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_true(cmp_skip_object_no_limit(&cmp));
-  assert_false(cmp_skip_object_no_limit(&cmp));
 
   M_BufferClear(&buf);
   assert_true(cmp_write_float(&cmp, 1.1f));

--- a/test/test.c
+++ b/test/test.c
@@ -262,16 +262,16 @@ static int skipper_successes = -1;
   assert_memory_equal(buf.data, fmt, dlen);                                   \
   M_BufferSeek(&buf, 0);                                                      \
   assert_true(cmp_read_object(&cmp, &obj));                                   \
-  assert_true(obj.as.ext.type == etype);                                      \
-  assert_true(obj.as.ext.size == esize);                                      \
+  assert_int_equal(obj.as.ext.type, etype);                                   \
+  assert_int_equal(obj.as.ext.size, esize);                                   \
   M_BufferSeek(&buf, 0);                                                      \
   do {                                                                        \
     char edata[esize];                                                        \
     int8_t dummy_type = 0;                                                    \
     uint32_t dummy_size = 0;                                                  \
     assert_true(cmp_read_ext(&cmp, &dummy_type, &dummy_size, edata));         \
-    assert_true(dummy_type == etype);                                         \
-    assert_true(dummy_size == esize);                                         \
+    assert_int_equal(dummy_type, etype);                                      \
+    assert_int_equal(dummy_size, esize);                                      \
     assert_memory_equal(edata, in, esize);                                    \
   } while (0)
 
@@ -4308,7 +4308,81 @@ void test_skipping(void **state) {
   assert_true(cmp_write_fixext4(&cmp, 3, "CCCC"));
   assert_true(cmp_write_fixext8(&cmp, 4, "CCCCCCCC"));
   assert_true(cmp_write_fixext16(&cmp, 5, "CCCCCCCCCCCCCCCC"));
+  assert_true(cmp_write_ext8(&cmp, 6, 2, "CC"));
+  assert_true(cmp_write_ext16(&cmp, 7, 2, "CC"));
+  assert_true(cmp_write_ext32(&cmp, 8, 2, "CC"));
+  assert_true(cmp_write_nil(&cmp));
   assert_true(cmp_write_array32(&cmp, 4));
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FLOAT);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_DOUBLE);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT1);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT2);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT4);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT8);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT16);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_FIXEXT16);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_EXT8);
 
   M_BufferSeek(&buf, 0);
   assert_true(cmp_skip_object_no_limit(&cmp));
@@ -4319,6 +4393,50 @@ void test_skipping(void **state) {
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
   assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_EXT16);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_EXT32);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_NIL);
+
+  M_BufferSeek(&buf, 0);
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_skip_object_no_limit(&cmp));
+  assert_true(cmp_read_object(&cmp, &obj));
+  assert_int_equal(obj.type, CMP_TYPE_ARRAY32);
 }
 
 void test_errors(void **state) {


### PR DESCRIPTION
Fixed a bug skipping EXT types.
Use size_t instead of uint64_t when skipping; no need to penalize platforms without hardware 64-bit types.
Fix new compiler warnings.