### PR TITLE
Support compiling without floating point operations

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -181,6 +181,7 @@ static uint64_t be64(uint64_t x) {
   return x;
 }
 
+#ifndef NO_FPU
 static float decode_befloat(char *b) {
   float f = 0.;
   char *fb = (char *)&f;
@@ -212,6 +213,7 @@ static double decode_bedouble(char *b) {
 
   return d;
 }
+#endif // NO_FPU
 
 static bool read_byte(cmp_ctx_t *ctx, uint8_t *x) {
   return ctx->read(ctx, x, sizeof(uint8_t));
@@ -641,6 +643,7 @@ static bool read_obj_data(cmp_ctx_t *ctx, uint8_t type_marker,
       return true;
     case CMP_TYPE_FLOAT:
     {
+#ifndef NO_FPU
       char bytes[4];
 
       if (!ctx->read(ctx, bytes, 4)) {
@@ -649,9 +652,13 @@ static bool read_obj_data(cmp_ctx_t *ctx, uint8_t type_marker,
       }
       obj->as.flt = decode_befloat(bytes);
       return true;
+#else // NO_FPU
+      return false;
+#endif // NO_FPU
     }
     case CMP_TYPE_DOUBLE:
     {
+#ifndef NO_FPU
       char bytes[8];
 
       if (!ctx->read(ctx, bytes, 8)) {
@@ -660,6 +667,9 @@ static bool read_obj_data(cmp_ctx_t *ctx, uint8_t type_marker,
       }
       obj->as.dbl = decode_bedouble(bytes);
       return true;
+#else // NO_FPU
+      return false;
+#endif // NO_FPU
     }
     case CMP_TYPE_BIN8:
     case CMP_TYPE_BIN16:
@@ -901,6 +911,7 @@ bool cmp_write_uinteger(cmp_ctx_t *ctx, uint64_t u) {
   return cmp_write_u64(ctx, u);
 }
 
+#ifndef NO_FPU
 bool cmp_write_float(cmp_ctx_t *ctx, float f) {
   if (!write_type_marker(ctx, FLOAT_MARKER))
     return false;
@@ -952,6 +963,7 @@ bool cmp_write_decimal(cmp_ctx_t *ctx, double d) {
   else
     return cmp_write_double(ctx, d);
 }
+#endif // NO_FPU
 
 bool cmp_write_nil(cmp_ctx_t *ctx) {
   return write_type_marker(ctx, NIL_MARKER);
@@ -1569,9 +1581,17 @@ bool cmp_write_object(cmp_ctx_t *ctx, cmp_object_t *obj) {
     case CMP_TYPE_EXT32:
       return cmp_write_ext32_marker(ctx, obj->as.ext.type, obj->as.ext.size);
     case CMP_TYPE_FLOAT:
+#ifndef NO_FPU
       return cmp_write_float(ctx, obj->as.flt);
+#else // NO_FPU
+      return false;
+#endif // NO_FPU
     case CMP_TYPE_DOUBLE:
+#ifndef NO_FPU
       return cmp_write_double(ctx, obj->as.dbl);
+#else // NO_FPU
+      return false;
+#endif
     case CMP_TYPE_UINT8:
       return cmp_write_u8(ctx, obj->as.u8);
     case CMP_TYPE_UINT16:
@@ -1645,9 +1665,17 @@ bool cmp_write_object_v4(cmp_ctx_t *ctx, cmp_object_t *obj) {
     case CMP_TYPE_EXT32:
       return cmp_write_ext32_marker(ctx, obj->as.ext.type, obj->as.ext.size);
     case CMP_TYPE_FLOAT:
+#ifndef NO_FPU
       return cmp_write_float(ctx, obj->as.flt);
+#else // NO_FPU
+        return false;
+#endif
     case CMP_TYPE_DOUBLE:
+#ifndef NO_FPU
       return cmp_write_double(ctx, obj->as.dbl);
+#else
+      return false;
+#endif
     case CMP_TYPE_UINT8:
       return cmp_write_u8(ctx, obj->as.u8);
     case CMP_TYPE_UINT16:
@@ -2171,6 +2199,7 @@ bool cmp_read_uinteger(cmp_ctx_t *ctx, uint64_t *d) {
   return cmp_read_ulong(ctx, d);
 }
 
+#ifndef NO_FPU
 bool cmp_read_float(cmp_ctx_t *ctx, float *f) {
   cmp_object_t obj;
 
@@ -2221,6 +2250,7 @@ bool cmp_read_decimal(cmp_ctx_t *ctx, double *d) {
       return false;
   }
 }
+#endif // NO_FPU
 
 bool cmp_read_nil(cmp_ctx_t *ctx) {
   cmp_object_t obj;
@@ -3199,6 +3229,7 @@ bool cmp_object_as_uinteger(cmp_object_t *obj, uint64_t *d) {
   return cmp_object_as_ulong(obj, d);
 }
 
+#ifndef NO_FPU
 bool cmp_object_as_float(cmp_object_t *obj, float *f) {
   if (obj->type == CMP_TYPE_FLOAT) {
     *f = obj->as.flt;
@@ -3216,6 +3247,7 @@ bool cmp_object_as_double(cmp_object_t *obj, double *d) {
 
   return false;
 }
+#endif // NO_FPU
 
 bool cmp_object_as_bool(cmp_object_t *obj, bool *b) {
   if (obj->type == CMP_TYPE_BOOLEAN) {

--- a/cmp.h
+++ b/cmp.h
@@ -85,8 +85,10 @@ union cmp_object_data_u {
   int16_t   s16;
   int32_t   s32;
   int64_t   s64;
+#ifndef NO_FPU
   float     flt;
   double    dbl;
+#endif // NO_FPU
   uint32_t  array_size;
   uint32_t  map_size;
   uint32_t  str_size;
@@ -147,11 +149,13 @@ bool cmp_write_integer(cmp_ctx_t *ctx, int64_t d);
 /* Writes an unsigned integer to the backend */
 bool cmp_write_uinteger(cmp_ctx_t *ctx, uint64_t u);
 
+#ifndef NO_FPU
 /*
  * Writes a floating-point value (either single or double-precision) to the
  * backend
  */
 bool cmp_write_decimal(cmp_ctx_t *ctx, double d);
+#endif // NO_FPU
 
 /* Writes NULL to the backend */
 bool cmp_write_nil(cmp_ctx_t *ctx);
@@ -265,11 +269,13 @@ bool cmp_read_ulong(cmp_ctx_t *ctx, uint64_t *u);
 /* Reads an unsigned integer */
 bool cmp_read_uinteger(cmp_ctx_t *ctx, uint64_t *u);
 
+#ifndef NO_FPU
 /*
  * Reads a floating point value (either single or double-precision) from the
  * backend
  */
 bool cmp_read_decimal(cmp_ctx_t *ctx, double *d);
+#endif // NO_FPU
 
 /* "Reads" (more like "skips") a NULL value from the backend */
 bool cmp_read_nil(cmp_ctx_t *ctx);
@@ -372,8 +378,10 @@ bool cmp_write_u16(cmp_ctx_t *ctx, uint16_t s);
 bool cmp_write_u32(cmp_ctx_t *ctx, uint32_t i);
 bool cmp_write_u64(cmp_ctx_t *ctx, uint64_t l);
 
+#ifndef NO_FPU
 bool cmp_write_float(cmp_ctx_t *ctx, float f);
 bool cmp_write_double(cmp_ctx_t *ctx, double d);
+#endif // NO_FPU
 
 bool cmp_write_fixstr_marker(cmp_ctx_t *ctx, uint8_t size);
 bool cmp_write_fixstr(cmp_ctx_t *ctx, const char *data, uint8_t size);
@@ -435,8 +443,10 @@ bool cmp_read_u16(cmp_ctx_t *ctx, uint16_t *s);
 bool cmp_read_u32(cmp_ctx_t *ctx, uint32_t *i);
 bool cmp_read_u64(cmp_ctx_t *ctx, uint64_t *l);
 
+#ifndef NO_FPU
 bool cmp_read_float(cmp_ctx_t *ctx, float *f);
 bool cmp_read_double(cmp_ctx_t *ctx, double *d);
+#endif // NO_FPU
 
 bool cmp_read_fixext1_marker(cmp_ctx_t *ctx, int8_t *type);
 bool cmp_read_fixext1(cmp_ctx_t *ctx, int8_t *type, void *data);


### PR DESCRIPTION
We would like to use the CMP library for kernel->user mode communication. But it is not allowed to use floating point instructions in the kernel. Therefore we have to exclude everything FPU related from code during compilation.