### PR TITLE
Make byte-wise float comparison intentional.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -24,6 +24,8 @@ THE SOFTWARE.
 
 #include "cmp.h"
 
+#include <string.h>
+
 static const uint32_t version = 19;
 static const uint32_t mp_version = 5;
 
@@ -976,7 +978,7 @@ bool cmp_write_decimal(cmp_ctx_t *ctx, double d) {
   float f = (float)d;
   double df = (double)f;
 
-  if (df == d)
+  if (memcmp(&df, &d, sizeof(df)) == 0)
     return cmp_write_float(ctx, f);
   else
     return cmp_write_double(ctx, d);


### PR DESCRIPTION
I'm less sure about this PR than the others. On the one hand, this makes the intention of
byte-wise float compare more obvious (and avoids a compiler warning `-Wfloat-equal`).
On the other hand, it adds a dependency on the `memcmp` function and the `string.h`
header, which hasn't been needed so far, and it's quite a nice property to only be depending
on very simple type headers and no C stdlib functions at all. Also, `memcmp` has less
type-safety.

So: feel free to reject this if you agree more strongly with the counter points.