### PR TITLE
cleanup: Fix some compiler warnings.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt-get install -y --no-install-recommends libcmocka-dev
+      - name: Build and test
+        run: make && make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= gcc
 CLANG ?= clang
 
-CFLAGS ?= -Werror -Wall -Wextra -funsigned-char -fwrapv -Wconversion -Wno-sign-conversion -Wmissing-format-attribute -Wpointer-arith -Wformat-nonliteral -Winit-self -Wwrite-strings -Wshadow -Wenum-compare -Wempty-body -Wparentheses -Wcast-align -Wstrict-aliasing --pedantic-errors
+CFLAGS ?= -Werror -Wall -Wextra -funsigned-char -fwrapv -Wconversion -Wno-c99-extensions -Wno-sign-conversion -Wmissing-format-attribute -Wpointer-arith -Wformat-nonliteral -Winit-self -Wwrite-strings -Wshadow -Wenum-compare -Wempty-body -Wparentheses -Wcast-align -Wstrict-aliasing --pedantic-errors
 CMPCFLAGS ?= -std=c89 -Wno-c99-extensions
 TESTCFLAGS ?= -std=c99 -Wno-error=deprecated-declarations -Wno-deprecated-declarations -O0
 NOFPUTESTCFLAGS ?= $(TESTCFLAGS) -DCMP_NO_FLOAT

--- a/cmp.c
+++ b/cmp.c
@@ -95,7 +95,7 @@ enum {
   ERROR_MAX
 };
 
-const char * const cmp_error_messages[ERROR_MAX + 1] = {
+static const char * const cmp_error_messages[ERROR_MAX + 1] = {
   "No Error",
   "Specified string data length is too long (> 0xFFFFFFFF)",
   "Specified binary data length is too long (> 0xFFFFFFFF)",
@@ -118,13 +118,11 @@ const char * const cmp_error_messages[ERROR_MAX + 1] = {
   "Max Error"
 };
 
-#if WORDS_BIGENDIAN == 0
-#define is_bigendian() (false)
-#elif WORDS_BIGENDIAN == 1
-#define is_bigendian() (true)
+#ifdef WORDS_BIGENDIAN
+#define is_bigendian() (WORDS_BIGENDIAN)
 #else
 static const int32_t _i = 1;
-#define is_bigendian() ((*(char *)&_i) == 0)
+#define is_bigendian() ((*(const char *)&_i) == 0)
 #endif
 
 static uint16_t be16(uint16_t x) {
@@ -2750,6 +2748,7 @@ bool cmp_skip_object(cmp_ctx_t *ctx, cmp_object_t *obj) {
           case CMP_TYPE_EXT16:
           case CMP_TYPE_EXT32:
             size++;
+            break;
           default:
             break;
         }
@@ -2816,6 +2815,7 @@ bool cmp_skip_object_flat(cmp_ctx_t *ctx, cmp_object_t *obj) {
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
               size++;
+              break;
             default:
               break;
           }
@@ -2892,6 +2892,7 @@ bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
               size++;
+              break;
             default:
               break;
           }
@@ -2983,6 +2984,7 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
               size++;
+              break;
             default:
               break;
           }

--- a/examples/example2.c
+++ b/examples/example2.c
@@ -52,8 +52,8 @@ static void error_and_exit(const char *msg) {
 }
 
 int main(void) {
-    FILE *fh = {0}
-    cmp_ctx_t cmp = {0}
+    FILE *fh = {0};
+    cmp_ctx_t cmp = {0};
     uint16_t year = 1983;
     uint8_t month = 5;
     uint8_t day = 28;


### PR DESCRIPTION
- Added `-Wno-c99-extensions` because we use `_Bool` (via `bool`).
- Added some missing `break`s in switch statements.
- Made the error string array `static`.
- Corrected treatment of `WORDS_BIGENDIAN` to be in accordance with the
  readme, which says if you don't set it, we default to runtime
  detection (which compilers actually optimise out).