### PR TITLE
Give global variable 'version' a less common name

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -24,8 +24,8 @@ THE SOFTWARE.
 
 #include "cmp.h"
 
-static const uint32_t version = 20;
-static const uint32_t mp_version = 5;
+static const uint32_t _cmp_version = 20;
+static const uint32_t _cmp_mp_version = 5;
 
 enum {
   POSITIVE_FIXNUM_MARKER = 0x00,
@@ -797,11 +797,11 @@ void cmp_init(cmp_ctx_t *ctx, void *buf, cmp_reader read,
 }
 
 uint32_t cmp_version(void) {
-  return version;
+  return _cmp_version;
 }
 
 uint32_t cmp_mp_version(void) {
-  return mp_version;
+  return _cmp_mp_version;
 }
 
 const char* cmp_strerror(cmp_ctx_t *ctx) {

--- a/cmp.h
+++ b/cmp.h
@@ -298,7 +298,7 @@ bool cmp_read_str_size(cmp_ctx_t *ctx, uint32_t *size);
 
 /*
  * Reads a string from the backend; according to the spec, the string's data
- * ought to be encoded using UTF-8, 
+ * ought to be encoded using UTF-8, but CMP leaves that job up to the programmer.
  */
 bool cmp_read_str(cmp_ctx_t *ctx, char *data, uint32_t *size);
 


### PR DESCRIPTION
This is useful when creating whole-program files by `cat`ing together all the translation units. `version` is more likely to be shadowed by function parameters than the proposed alternatives.