### PR TITLE
cleanup: Avoid implicit int-to-bool conversions.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -246,7 +246,7 @@ static bool read_byte(cmp_ctx_t *ctx, uint8_t *x) {
 }
 
 static bool write_byte(cmp_ctx_t *ctx, uint8_t x) {
-  return (ctx->write(ctx, &x, sizeof(uint8_t)) == (sizeof(uint8_t)));
+  return ctx->write(ctx, &x, sizeof(uint8_t)) == sizeof(uint8_t);
 }
 
 static bool skip_bytes(cmp_ctx_t *ctx, size_t count) {
@@ -841,7 +841,7 @@ bool cmp_write_s8(cmp_ctx_t *ctx, int8_t c) {
   if (!write_type_marker(ctx, S8_MARKER))
     return false;
 
-  return ctx->write(ctx, &c, sizeof(int8_t));
+  return ctx->write(ctx, &c, sizeof(int8_t)) == sizeof(int8_t);
 }
 
 bool cmp_write_s16(cmp_ctx_t *ctx, int16_t s) {
@@ -850,7 +850,7 @@ bool cmp_write_s16(cmp_ctx_t *ctx, int16_t s) {
 
   s = sbe16(s);
 
-  return ctx->write(ctx, &s, sizeof(int16_t));
+  return ctx->write(ctx, &s, sizeof(int16_t)) == sizeof(int16_t);
 }
 
 bool cmp_write_s32(cmp_ctx_t *ctx, int32_t i) {
@@ -859,7 +859,7 @@ bool cmp_write_s32(cmp_ctx_t *ctx, int32_t i) {
 
   i = sbe32(i);
 
-  return ctx->write(ctx, &i, sizeof(int32_t));
+  return ctx->write(ctx, &i, sizeof(int32_t)) == sizeof(int32_t);
 }
 
 bool cmp_write_s64(cmp_ctx_t *ctx, int64_t l) {
@@ -868,7 +868,7 @@ bool cmp_write_s64(cmp_ctx_t *ctx, int64_t l) {
 
   l = sbe64(l);
 
-  return ctx->write(ctx, &l, sizeof(int64_t));
+  return ctx->write(ctx, &l, sizeof(int64_t)) == sizeof(int64_t);
 }
 
 bool cmp_write_integer(cmp_ctx_t *ctx, int64_t d) {
@@ -894,7 +894,7 @@ bool cmp_write_u8(cmp_ctx_t *ctx, uint8_t c) {
   if (!write_type_marker(ctx, U8_MARKER))
     return false;
 
-  return ctx->write(ctx, &c, sizeof(uint8_t));
+  return ctx->write(ctx, &c, sizeof(uint8_t)) == sizeof(uint8_t);
 }
 
 bool cmp_write_u16(cmp_ctx_t *ctx, uint16_t s) {
@@ -903,7 +903,7 @@ bool cmp_write_u16(cmp_ctx_t *ctx, uint16_t s) {
 
   s = be16(s);
 
-  return ctx->write(ctx, &s, sizeof(uint16_t));
+  return ctx->write(ctx, &s, sizeof(uint16_t)) == sizeof(uint16_t);
 }
 
 bool cmp_write_u32(cmp_ctx_t *ctx, uint32_t i) {
@@ -912,7 +912,7 @@ bool cmp_write_u32(cmp_ctx_t *ctx, uint32_t i) {
 
   i = be32(i);
 
-  return ctx->write(ctx, &i, sizeof(uint32_t));
+  return ctx->write(ctx, &i, sizeof(uint32_t)) == sizeof(uint32_t);
 }
 
 bool cmp_write_u64(cmp_ctx_t *ctx, uint64_t l) {
@@ -921,7 +921,7 @@ bool cmp_write_u64(cmp_ctx_t *ctx, uint64_t l) {
 
   l = be64(l);
 
-  return ctx->write(ctx, &l, sizeof(uint64_t));
+  return ctx->write(ctx, &l, sizeof(uint64_t)) == sizeof(uint64_t);
 }
 
 bool cmp_write_uinteger(cmp_ctx_t *ctx, uint64_t u) {
@@ -955,10 +955,10 @@ bool cmp_write_float(cmp_ctx_t *ctx, float f) {
     for (i = 0; i < sizeof(float); i++)
       swapped[i] = fbuf[sizeof(float) - i - 1];
 
-    return ctx->write(ctx, swapped, sizeof(float));
+    return ctx->write(ctx, swapped, sizeof(float)) == sizeof(float);
   }
 
-  return ctx->write(ctx, &f, sizeof(float));
+  return ctx->write(ctx, &f, sizeof(float)) == sizeof(float);
 }
 
 bool cmp_write_double(cmp_ctx_t *ctx, double d) {
@@ -974,10 +974,10 @@ bool cmp_write_double(cmp_ctx_t *ctx, double d) {
     for (i = 0; i < sizeof(double); i++)
       swapped[i] = dbuf[sizeof(double) - i - 1];
 
-    return ctx->write(ctx, swapped, sizeof(double));
+    return ctx->write(ctx, swapped, sizeof(double)) == sizeof(double);
   }
 
-  return ctx->write(ctx, &d, sizeof(double));
+  return ctx->write(ctx, &d, sizeof(double)) == sizeof(double);
 }
 
 bool cmp_write_decimal(cmp_ctx_t *ctx, double d) {
@@ -1032,7 +1032,7 @@ bool cmp_write_fixstr(cmp_ctx_t *ctx, const char *data, uint8_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1043,7 +1043,7 @@ bool cmp_write_str8_marker(cmp_ctx_t *ctx, uint8_t size) {
   if (!write_type_marker(ctx, STR8_MARKER))
     return false;
 
-  if (ctx->write(ctx, &size, sizeof(uint8_t)))
+  if (ctx->write(ctx, &size, sizeof(uint8_t)) == sizeof(uint8_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1057,7 +1057,7 @@ bool cmp_write_str8(cmp_ctx_t *ctx, const char *data, uint8_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1070,7 +1070,7 @@ bool cmp_write_str16_marker(cmp_ctx_t *ctx, uint16_t size) {
 
   size = be16(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint16_t)))
+  if (ctx->write(ctx, &size, sizeof(uint16_t)) == sizeof(uint16_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1084,7 +1084,7 @@ bool cmp_write_str16(cmp_ctx_t *ctx, const char *data, uint16_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1097,7 +1097,7 @@ bool cmp_write_str32_marker(cmp_ctx_t *ctx, uint32_t size) {
 
   size = be32(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint32_t)))
+  if (ctx->write(ctx, &size, sizeof(uint32_t)) == sizeof(uint32_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1111,7 +1111,7 @@ bool cmp_write_str32(cmp_ctx_t *ctx, const char *data, uint32_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1162,7 +1162,7 @@ bool cmp_write_bin8_marker(cmp_ctx_t *ctx, uint8_t size) {
   if (!write_type_marker(ctx, BIN8_MARKER))
     return false;
 
-  if (ctx->write(ctx, &size, sizeof(uint8_t)))
+  if (ctx->write(ctx, &size, sizeof(uint8_t)) == sizeof(uint8_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1176,7 +1176,7 @@ bool cmp_write_bin8(cmp_ctx_t *ctx, const void *data, uint8_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1189,7 +1189,7 @@ bool cmp_write_bin16_marker(cmp_ctx_t *ctx, uint16_t size) {
 
   size = be16(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint16_t)))
+  if (ctx->write(ctx, &size, sizeof(uint16_t)) == sizeof(uint16_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1203,7 +1203,7 @@ bool cmp_write_bin16(cmp_ctx_t *ctx, const void *data, uint16_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1216,7 +1216,7 @@ bool cmp_write_bin32_marker(cmp_ctx_t *ctx, uint32_t size) {
 
   size = be32(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint32_t)))
+  if (ctx->write(ctx, &size, sizeof(uint32_t)) == sizeof(uint32_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1230,7 +1230,7 @@ bool cmp_write_bin32(cmp_ctx_t *ctx, const void *data, uint32_t size) {
   if (size == 0)
     return true;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1269,7 +1269,7 @@ bool cmp_write_array16(cmp_ctx_t *ctx, uint16_t size) {
 
   size = be16(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint16_t)))
+  if (ctx->write(ctx, &size, sizeof(uint16_t)) == sizeof(uint16_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1282,7 +1282,7 @@ bool cmp_write_array32(cmp_ctx_t *ctx, uint32_t size) {
 
   size = be32(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint32_t)))
+  if (ctx->write(ctx, &size, sizeof(uint32_t)) == sizeof(uint32_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1312,7 +1312,7 @@ bool cmp_write_map16(cmp_ctx_t *ctx, uint16_t size) {
 
   size = be16(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint16_t)))
+  if (ctx->write(ctx, &size, sizeof(uint16_t)) == sizeof(uint16_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1325,7 +1325,7 @@ bool cmp_write_map32(cmp_ctx_t *ctx, uint32_t size) {
 
   size = be32(size);
 
-  if (ctx->write(ctx, &size, sizeof(uint32_t)))
+  if (ctx->write(ctx, &size, sizeof(uint32_t)) == sizeof(uint32_t))
     return true;
 
   ctx->error = LENGTH_WRITING_ERROR;
@@ -1345,7 +1345,7 @@ bool cmp_write_fixext1_marker(cmp_ctx_t *ctx, int8_t type) {
   if (!write_type_marker(ctx, FIXEXT1_MARKER))
     return false;
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1356,7 +1356,7 @@ bool cmp_write_fixext1(cmp_ctx_t *ctx, int8_t type, const void *data) {
   if (!cmp_write_fixext1_marker(ctx, type))
     return false;
 
-  if (ctx->write(ctx, data, 1))
+  if (ctx->write(ctx, data, 1) == 1)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1367,7 +1367,7 @@ bool cmp_write_fixext2_marker(cmp_ctx_t *ctx, int8_t type) {
   if (!write_type_marker(ctx, FIXEXT2_MARKER))
     return false;
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1378,7 +1378,7 @@ bool cmp_write_fixext2(cmp_ctx_t *ctx, int8_t type, const void *data) {
   if (!cmp_write_fixext2_marker(ctx, type))
     return false;
 
-  if (ctx->write(ctx, data, 2))
+  if (ctx->write(ctx, data, 2) == 2)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1389,7 +1389,7 @@ bool cmp_write_fixext4_marker(cmp_ctx_t *ctx, int8_t type) {
   if (!write_type_marker(ctx, FIXEXT4_MARKER))
     return false;
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1400,7 +1400,7 @@ bool cmp_write_fixext4(cmp_ctx_t *ctx, int8_t type, const void *data) {
   if (!cmp_write_fixext4_marker(ctx, type))
     return false;
 
-  if (ctx->write(ctx, data, 4))
+  if (ctx->write(ctx, data, 4) == 4)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1411,7 +1411,7 @@ bool cmp_write_fixext8_marker(cmp_ctx_t *ctx, int8_t type) {
   if (!write_type_marker(ctx, FIXEXT8_MARKER))
     return false;
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1422,7 +1422,7 @@ bool cmp_write_fixext8(cmp_ctx_t *ctx, int8_t type, const void *data) {
   if (!cmp_write_fixext8_marker(ctx, type))
     return false;
 
-  if (ctx->write(ctx, data, 8))
+  if (ctx->write(ctx, data, 8) == 8)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1433,7 +1433,7 @@ bool cmp_write_fixext16_marker(cmp_ctx_t *ctx, int8_t type) {
   if (!write_type_marker(ctx, FIXEXT16_MARKER))
     return false;
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1444,7 +1444,7 @@ bool cmp_write_fixext16(cmp_ctx_t *ctx, int8_t type, const void *data) {
   if (!cmp_write_fixext16_marker(ctx, type))
     return false;
 
-  if (ctx->write(ctx, data, 16))
+  if (ctx->write(ctx, data, 16) == 16)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1455,12 +1455,12 @@ bool cmp_write_ext8_marker(cmp_ctx_t *ctx, int8_t type, uint8_t size) {
   if (!write_type_marker(ctx, EXT8_MARKER))
     return false;
 
-  if (!ctx->write(ctx, &size, sizeof(uint8_t))) {
+  if (ctx->write(ctx, &size, sizeof(uint8_t)) != sizeof(uint8_t)) {
     ctx->error = LENGTH_WRITING_ERROR;
     return false;
   }
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1471,7 +1471,7 @@ bool cmp_write_ext8(cmp_ctx_t *ctx, int8_t type, uint8_t size, const void *data)
   if (!cmp_write_ext8_marker(ctx, type, size))
     return false;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1484,12 +1484,12 @@ bool cmp_write_ext16_marker(cmp_ctx_t *ctx, int8_t type, uint16_t size) {
 
   size = be16(size);
 
-  if (!ctx->write(ctx, &size, sizeof(uint16_t))) {
+  if (ctx->write(ctx, &size, sizeof(uint16_t)) != sizeof(uint16_t)) {
     ctx->error = LENGTH_WRITING_ERROR;
     return false;
   }
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1500,7 +1500,7 @@ bool cmp_write_ext16(cmp_ctx_t *ctx, int8_t type, uint16_t size, const void *dat
   if (!cmp_write_ext16_marker(ctx, type, size))
     return false;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;
@@ -1513,12 +1513,12 @@ bool cmp_write_ext32_marker(cmp_ctx_t *ctx, int8_t type, uint32_t size) {
 
   size = be32(size);
 
-  if (!ctx->write(ctx, &size, sizeof(uint32_t))) {
+  if (ctx->write(ctx, &size, sizeof(uint32_t)) != sizeof(uint32_t)) {
     ctx->error = LENGTH_WRITING_ERROR;
     return false;
   }
 
-  if (ctx->write(ctx, &type, sizeof(int8_t)))
+  if (ctx->write(ctx, &type, sizeof(int8_t)) == sizeof(int8_t))
     return true;
 
   ctx->error = EXT_TYPE_WRITING_ERROR;
@@ -1529,7 +1529,7 @@ bool cmp_write_ext32(cmp_ctx_t *ctx, int8_t type, uint32_t size, const void *dat
   if (!cmp_write_ext32_marker(ctx, type, size))
     return false;
 
-  if (ctx->write(ctx, data, size))
+  if (ctx->write(ctx, data, size) == size)
     return true;
 
   ctx->error = DATA_WRITING_ERROR;


### PR DESCRIPTION
IMPORTANT: This is a semantic change. Previously, it would count as a success if writing 64 bits results in actually writing only 1 byte, 2 bytes, or writing 10 bytes instead of the expected 8. Now, only writing exactly 8 bytes as requested counts as success.