### PR TITLE
test: Enable more sanitizers in ubsan tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,13 @@ jobs:
         run: make -j4
       - name: Build test programs
         run: make testprogs
-      - name: Run tests
-        run: make test
+      - name: Run unit tests
+        run: make unittest
+      - name: Run ASAN tests
+        run: make addrtest
+      - name: Run MSAN tests
+        run: make memtest
+      - name: Run UBSAN tests
+        run: make ubtest
+      - name: Run tests without FPU (no float)
+        run: make nofloattest

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NOFPUTESTCFLAGS ?= $(TESTCFLAGS) -DCMP_NO_FLOAT
 ADDRCFLAGS ?= -fsanitize=address
 MEMCFLAGS ?= -fsanitize=memory -fno-omit-frame-pointer \
 			 -fno-optimize-sibling-calls
-UBCFLAGS ?= -fsanitize=undefined
+UBCFLAGS ?= -fsanitize=undefined,nullability,local-bounds,float-divide-by-zero,integer
 
 .PHONY: all clean test coverage
 


### PR DESCRIPTION
cmp does a lot of work with integers and some with floats, so it's good to have checks for undefined behaviour on those data types.