### PR TITLE
cleanup: Use hex constants for i8/i16/i32/i64 limits.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -820,7 +820,7 @@ bool cmp_write_pfix(cmp_ctx_t *ctx, uint8_t c) {
 }
 
 bool cmp_write_nfix(cmp_ctx_t *ctx, int8_t c) {
-  if (c >= -32 && c <= -1)
+  if (c >= -0x20 && c <= -1)
     return write_fixed_value(ctx, (uint8_t)c);
 
   ctx->error = INPUT_VALUE_TOO_LARGE_ERROR;
@@ -830,7 +830,7 @@ bool cmp_write_nfix(cmp_ctx_t *ctx, int8_t c) {
 bool cmp_write_sfix(cmp_ctx_t *ctx, int8_t c) {
   if (c >= 0)
     return cmp_write_pfix(ctx, (uint8_t)c);
-  if (c >= -32 && c <= -1)
+  if (c >= -0x20 && c <= -1)
     return cmp_write_nfix(ctx, c);
 
   ctx->error = INPUT_VALUE_TOO_LARGE_ERROR;
@@ -874,13 +874,13 @@ bool cmp_write_s64(cmp_ctx_t *ctx, int64_t l) {
 bool cmp_write_integer(cmp_ctx_t *ctx, int64_t d) {
   if (d >= 0)
     return cmp_write_uinteger(ctx, (uint64_t)d);
-  if (d >= -32)
+  if (d >= -0x20)
     return cmp_write_nfix(ctx, (int8_t)d);
-  if (d >= -128)
+  if (d >= -0x80)
     return cmp_write_s8(ctx, (int8_t)d);
-  if (d >= -32768)
+  if (d >= -0x8000)
     return cmp_write_s16(ctx, (int16_t)d);
-  if (d >= (-2147483647 - 1))
+  if (d >= -INT64_C(0x80000000))
     return cmp_write_s32(ctx, (int32_t)d);
 
   return cmp_write_s64(ctx, d);
@@ -1872,7 +1872,7 @@ bool cmp_read_char(cmp_ctx_t *ctx, int8_t *c) {
       *c = obj.as.s8;
       return true;
     case CMP_TYPE_UINT8:
-      if (obj.as.u8 <= 127) {
+      if (obj.as.u8 <= 0x7F) {
         *c = (int8_t)obj.as.u8;
         return true;
       }
@@ -1904,7 +1904,7 @@ bool cmp_read_short(cmp_ctx_t *ctx, int16_t *s) {
       *s = obj.as.s16;
       return true;
     case CMP_TYPE_UINT16:
-      if (obj.as.u16 <= 32767) {
+      if (obj.as.u16 <= 0x7FFF) {
         *s = (int16_t)obj.as.u16;
         return true;
       }
@@ -1942,7 +1942,7 @@ bool cmp_read_int(cmp_ctx_t *ctx, int32_t *i) {
       *i = obj.as.s32;
       return true;
     case CMP_TYPE_UINT32:
-      if (obj.as.u32 <= 2147483647) {
+      if (obj.as.u32 <= 0x7FFFFFFF) {
         *i = (int32_t)obj.as.u32;
         return true;
       }
@@ -1986,7 +1986,7 @@ bool cmp_read_long(cmp_ctx_t *ctx, int64_t *d) {
       *d = obj.as.s64;
       return true;
     case CMP_TYPE_UINT64:
-      if (obj.as.u64 <= 9223372036854775807) {
+      if (obj.as.u64 <= UINT64_C(0x7FFFFFFFFFFFFFFF)) {
         *d = (int64_t)obj.as.u64;
         return true;
       }
@@ -3228,7 +3228,7 @@ bool cmp_object_as_char(const cmp_object_t *obj, int8_t *c) {
       *c = obj->as.s8;
       return true;
     case CMP_TYPE_UINT8:
-      if (obj->as.u8 <= 127) {
+      if (obj->as.u8 <= 0x7F) {
         *c = obj->as.s8;
         return true;
       }
@@ -3254,7 +3254,7 @@ bool cmp_object_as_short(const cmp_object_t *obj, int16_t *s) {
       *s = obj->as.s16;
       return true;
     case CMP_TYPE_UINT16:
-      if (obj->as.u16 <= 32767) {
+      if (obj->as.u16 <= 0x7FFF) {
         *s = (int16_t)obj->as.u16;
         return true;
       }
@@ -3286,7 +3286,7 @@ bool cmp_object_as_int(const cmp_object_t *obj, int32_t *i) {
       *i = obj->as.s32;
       return true;
     case CMP_TYPE_UINT32:
-      if (obj->as.u32 <= 2147483647) {
+      if (obj->as.u32 <= 0x7FFFFFFF) {
         *i = (int32_t)obj->as.u32;
         return true;
       }
@@ -3324,7 +3324,7 @@ bool cmp_object_as_long(const cmp_object_t *obj, int64_t *d) {
       *d = obj->as.s64;
       return true;
     case CMP_TYPE_UINT64:
-      if (obj->as.u64 <= 9223372036854775807) {
+      if (obj->as.u64 <= UINT64_C(0x7FFFFFFFFFFFFFFF)) {
         *d = (int64_t)obj->as.u64;
         return true;
       }


### PR DESCRIPTION
The rest of the code uses mostly hex constants, which are much less error-prone than a complicated number like 9223372036834775807 (in which I made a mistake, but it's hard to spot).

I've only put `UINT64_C` around the 64 bit constant, because those macros aren't used anywhere else in the code. This avoids some warnings in overly strict compilers (cstd 6.4.4.1 allows large integer constants and puts them into whatever type can represent them, but some compilers warn about it anyway and ask you to put suffixes like `ULL`).