### PR TITLE
cleanup: Mark input pointer type for `cmp_strerror` as `const`.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -780,7 +780,7 @@ uint32_t cmp_mp_version(void) {
   return cmp_mp_version_;
 }
 
-const char* cmp_strerror(cmp_ctx_t *ctx) {
+const char* cmp_strerror(const cmp_ctx_t *ctx) {
   if (ctx->error > CMP_ERROR_NONE && ctx->error < CMP_ERROR_MAX)
     return cmp_error_message((cmp_error_t)ctx->error);
 

--- a/cmp.h
+++ b/cmp.h
@@ -145,7 +145,7 @@ uint32_t cmp_version(void);
 uint32_t cmp_mp_version(void);
 
 /* Returns a string description of a CMP context's error */
-const char* cmp_strerror(cmp_ctx_t *ctx);
+const char* cmp_strerror(const cmp_ctx_t *ctx);
 
 /* Writes a signed integer to the backend */
 bool cmp_write_integer(cmp_ctx_t *ctx, int64_t d);


### PR DESCRIPTION
Its members are never mutated.