### PR TITLE
Don't ignore errors reported by skip_bytes()

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -2739,7 +2739,9 @@ bool cmp_skip_object(cmp_ctx_t *ctx, cmp_object_t *obj) {
             break;
         }
 
-        skip_bytes(ctx, size);
+        if (!skip_bytes(ctx, size)) {
+          return false;
+        }
       }
   }
 
@@ -2806,7 +2808,9 @@ bool cmp_skip_object_flat(cmp_ctx_t *ctx, cmp_object_t *obj) {
               break;
           }
 
-          skip_bytes(ctx, size);
+          if (!skip_bytes(ctx, size)) {
+            return false;
+          }
         }
     }
 
@@ -2883,7 +2887,9 @@ bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
               break;
           }
 
-          skip_bytes(ctx, size);
+          if (!skip_bytes(ctx, size)) {
+            return false;
+          }
         }
     }
 
@@ -2975,7 +2981,9 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
               break;
           }
 
-          skip_bytes(ctx, size);
+          if (!skip_bytes(ctx, size)) {
+            return false;
+          }
         }
     }
 

--- a/test/test.c
+++ b/test/test.c
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 int main(void) {
   /* Use the old CMocka API because Travis' latest Ubuntu is Trusty */
-  const UnitTest tests[17] = {
+  const UnitTest tests[18] = {
     unit_test(test_msgpack),
     unit_test(test_fixedint),
     unit_test(test_numbers),
@@ -51,6 +51,7 @@ int main(void) {
 #endif
 
     unit_test(test_skipping),
+    unit_test(test_skip_bytes),
     unit_test(test_deprecated_limited_skipping),
     unit_test(test_errors),
     unit_test(test_version),

--- a/test/tests.c
+++ b/test/tests.c
@@ -4696,6 +4696,37 @@ void test_skipping(void **state) {
   teardown_cmp_and_buf(&cmp, &buf);
 }
 
+void test_skip_bytes(void **state) {
+  buf_t buf;
+  cmp_ctx_t cmp;
+  cmp_object_t obj;
+
+  (void)state;
+
+  setup_cmp_and_buf(&cmp, &buf);
+
+  M_BufferEnsureCapacity(&buf, 100);
+
+  /* Write the string marker but omit the string contents. This should ensure
+     that skip_bytes() (and thus cmp_skip_object*) will fail when it tries
+     to skip the string. */
+  assert_true(cmp_write_str_marker(&cmp, 20));
+
+  M_BufferSeek(&buf, 0);
+  assert_false(cmp_skip_object(&cmp, &obj));
+
+  M_BufferSeek(&buf, 0);
+  assert_false(cmp_skip_object_flat(&cmp, &obj));
+
+  M_BufferSeek(&buf, 0);
+  assert_false(cmp_skip_object_no_limit(&cmp));
+
+  M_BufferSeek(&buf, 0);
+  assert_false(cmp_skip_object_limit(&cmp, &obj, 1));
+
+  teardown_cmp_and_buf(&cmp, &buf);
+}
+
 void test_deprecated_limited_skipping(void **state) {
   buf_t buf;
   cmp_ctx_t cmp;

--- a/test/tests.h
+++ b/test/tests.h
@@ -38,6 +38,7 @@ void test_obj(void **state);
 void test_float_flip(void **state);
 #endif
 void test_skipping(void **state);
+void test_skip_bytes(void **state);
 void test_deprecated_limited_skipping(void **state);
 void test_errors(void **state);
 void test_version(void **state);


### PR DESCRIPTION
If our read or skip callback reports an error here we should return immediately, rather than ignoring the error.